### PR TITLE
Refactor BlockNotice.sol to use custom error NoticeDoesNotExist

### DIFF
--- a/blockchain/contracts/BlockNotice.sol
+++ b/blockchain/contracts/BlockNotice.sol
@@ -13,6 +13,8 @@ contract BlockNotice {
     Notice[] public notices;
     mapping(address => uint256[]) public userNotices;
 
+    error NoticeDoesNotExist(uint256 id);
+
     event NoticePosted(
         uint256 indexed noticeId,
         address indexed author,
@@ -35,7 +37,7 @@ contract BlockNotice {
         view
         returns (Notice memory)
     {
-        require(_id < notices.length, "Notice does not exist");
+        if (_id >= notices.length) revert NoticeDoesNotExist(_id);
         return notices[_id];
     }
 

--- a/blockchain/test/BlockNotice.cjs
+++ b/blockchain/test/BlockNotice.cjs
@@ -1,0 +1,14 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("BlockNotice", function () {
+  it("Should revert with the right error if notice does not exist", async function () {
+    const BlockNotice = await ethers.getContractFactory("BlockNotice");
+    const blockNotice = await BlockNotice.deploy();
+
+    // Test for ID 0 when notices is empty
+    await expect(blockNotice.getNotice(0))
+      .to.be.revertedWithCustomError(blockNotice, "NoticeDoesNotExist")
+      .withArgs(0);
+  });
+});


### PR DESCRIPTION
Replaced `require` with custom error `NoticeDoesNotExist(uint256 id)` in `getNotice` function to improve gas efficiency and code health.

- Added `NoticeDoesNotExist` error definition.
- Updated `getNotice` to revert with custom error.
- Added test coverage in `blockchain/test/BlockNotice.cjs`.
- Verified changes with tests and deployment script.

---
*PR created automatically by Jules for task [15975184520227362317](https://jules.google.com/task/15975184520227362317) started by @revxi*