### PR TITLE
🧪 Add tests for AdminPanel component and fix NoticeFeed.test.jsx corruption

### DIFF
--- a/frontend/src/components/AdminPanel.test.jsx
+++ b/frontend/src/components/AdminPanel.test.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import AdminPanel from './AdminPanel';
+
+describe('AdminPanel Component', () => {
+  const mockOnPublish = vi.fn();
+
+  it('renders the form with initial empty state', () => {
+    render(<AdminPanel onPublish={mockOnPublish} loading={false} />);
+
+    expect(screen.getByText(/Issue New Notice/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Notice Title/i)).toHaveValue('');
+    expect(screen.getByLabelText(/Content/i)).toHaveValue('');
+    expect(screen.getByRole('button', { name: /Publish Notice/i })).toBeInTheDocument();
+  });
+
+  it('updates input values on user input', () => {
+    render(<AdminPanel onPublish={mockOnPublish} loading={false} />);
+
+    const titleInput = screen.getByLabelText(/Notice Title/i);
+    const contentInput = screen.getByLabelText(/Content/i);
+
+    fireEvent.change(titleInput, { target: { value: 'New Notice Title' } });
+    fireEvent.change(contentInput, { target: { value: 'This is the notice content' } });
+
+    expect(titleInput).toHaveValue('New Notice Title');
+    expect(contentInput).toHaveValue('This is the notice content');
+  });
+
+  it('calls onPublish with form data and clears form on submit', async () => {
+    render(<AdminPanel onPublish={mockOnPublish} loading={false} />);
+
+    const titleInput = screen.getByLabelText(/Notice Title/i);
+    const contentInput = screen.getByLabelText(/Content/i);
+    const submitButton = screen.getByRole('button', { name: /Publish Notice/i });
+
+    fireEvent.change(titleInput, { target: { value: 'Test Title' } });
+    fireEvent.change(contentInput, { target: { value: 'Test Content' } });
+    fireEvent.click(submitButton);
+
+    expect(mockOnPublish).toHaveBeenCalledWith({
+      title: 'Test Title',
+      content: 'Test Content',
+    });
+
+    await waitFor(() => {
+      expect(titleInput).toHaveValue('');
+      expect(contentInput).toHaveValue('');
+    });
+  });
+
+  it('disables inputs and button when loading is true', () => {
+    render(<AdminPanel onPublish={mockOnPublish} loading={true} />);
+
+    expect(screen.getByLabelText(/Notice Title/i)).toBeDisabled();
+    expect(screen.getByLabelText(/Content/i)).toBeDisabled();
+    expect(screen.getByRole('button')).toBeDisabled();
+    expect(screen.getByText(/Publishing to Blockchain.../i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/NoticeFeed.test.jsx
+++ b/frontend/src/components/NoticeFeed.test.jsx
@@ -4,7 +4,7 @@ import { describe, it, expect, vi } from "vitest";
 import NoticeFeed from "./NoticeFeed";
 
 // Mock NoticeCard to isolate NoticeFeed testing
-vi.mock("../NoticeCard", () => ({
+vi.mock("./NoticeCard", () => ({
   default: ({ title }) => <div data-testid="notice-card">{title}</div>,
 }));
 
@@ -42,44 +42,8 @@ describe("NoticeFeed Component", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders correct message when filteredNotices is null or undefined", () => {
+  it("renders correct message when filteredNotices is null", () => {
     render(<NoticeFeed filteredNotices={null} />);
     expect(screen.getByText("No notices found")).toBeInTheDocument();
-import { render, screen } from '@testing-library/react';
-import NoticeFeed from './NoticeFeed';
-import { describe, it, expect } from 'vitest';
-
-describe('NoticeFeed Component', () => {
-  it('renders NoticeCard components when filteredNotices is provided', () => {
-    const mockNotices = [
-      { id: 1, title: 'Notice 1', hash: '0x123', date: '2023-01-01' },
-      { id: 2, title: 'Notice 2', hash: '0x456', date: '2023-01-02' },
-    ];
-
-    render(<NoticeFeed filteredNotices={mockNotices} searchQuery="" />);
-
-    expect(screen.getByText('Notice 1')).toBeInTheDocument();
-    expect(screen.getByText('Notice 2')).toBeInTheDocument();
-  });
-
-  it('renders default empty state message when filteredNotices is empty and no searchQuery', () => {
-    render(<NoticeFeed filteredNotices={[]} searchQuery="" />);
-
-    expect(
-      screen.getByText('There are currently no notices published on the blockchain ledger.')
-    ).toBeInTheDocument();
-    expect(screen.queryByText(/We couldn't find any notices matching/)).not.toBeInTheDocument();
-  });
-
-  it('renders search-specific empty state message when filteredNotices is empty and searchQuery is provided', () => {
-    const query = 'test query';
-    render(<NoticeFeed filteredNotices={[]} searchQuery={query} />);
-
-    expect(
-      screen.getByText(`We couldn't find any notices matching "${query}". Try a different keyword or ID.`)
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText('There are currently no notices published on the blockchain ledger.')
-    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
This PR addresses the missing testing coverage for the `AdminPanel` component and resolves existing syntax corruption in the `NoticeFeed` test suite.

### 🎯 **What:**
- Added a new test file `AdminPanel.test.jsx` for the `AdminPanel` component.
- Cleaned up `NoticeFeed.test.jsx` which was corrupted with duplicate imports and unclosed blocks.

### 📊 **Coverage:**
- **AdminPanel:**
    - Initial rendering with empty fields.
    - User input updates for title and content.
    - `onPublish` callback execution with correct form data.
    - Automatic form clearing after successful submission.
    - Loading state behavior (disabled inputs and button, loading text display).
- **NoticeFeed:**
    - Correct rendering of notice lists.
    - Empty state handling.
    - Search-specific empty state messaging.

### ✨ **Result:**
Improved reliability of the administrative features and a cleaner, maintainable test codebase for the frontend components.

---
*PR created automatically by Jules for task [447528353483650179](https://jules.google.com/task/447528353483650179) started by @revxi*