### PR TITLE
🔒 Fix Insecure Randomness for IPFS Hash Simulation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo, useEffect, useCallback } from "react";
 import { useAccount, useConnect, useDisconnect, useReadContract, useReadContracts, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
 import ABI from "./utils/abi.json";
+import { generateIPFSHash } from "./utils/ipfs";
 import { Search, ShieldCheck, User, Wallet, LayoutGrid } from "lucide-react";
 import AdminPanel from "./components/AdminPanel";
 import NoticeFeed from "./components/NoticeFeed";
@@ -100,13 +101,13 @@ export default function App() {
     if (userRole !== "admin") return alert("Unauthorized: Admins only.");
 
     try {
-      // Simulate IPFS Hashing of content
-      const mockHash = "Qm" + Math.random().toString(36).substring(2, 15);
+      // Securely simulate IPFS Hashing of content
+      const secureHash = await generateIPFSHash(formData.content);
       await writeContractAsync({
         address: CONTRACT_ADDRESS,
         abi: ABI,
         functionName: 'postNotice',
-        args: [formData.title, mockHash],
+        args: [formData.title, secureHash],
       });
       fetchNotices();
     } catch (err) {

--- a/frontend/src/utils/ipfs.js
+++ b/frontend/src/utils/ipfs.js
@@ -1,0 +1,47 @@
+const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+function base58Encode(uint8Array) {
+  let x = BigInt(0);
+  for (const byte of uint8Array) {
+    x = x * 256n + BigInt(byte);
+  }
+
+  let result = '';
+  while (x > 0n) {
+    result = ALPHABET[Number(x % 58n)] + result;
+    x = x / 58n;
+  }
+
+  // Handle leading zeros
+  for (let i = 0; i < uint8Array.length && uint8Array[i] === 0; i++) {
+    result = ALPHABET[0] + result;
+  }
+
+  return result;
+}
+
+/**
+ * Simulates generating an IPFS CIDv0 hash for the given content.
+ * Uses SHA-256 and Base58 encoding with the multihash prefix (0x1220).
+ * @param {string} content - The content to hash.
+ * @returns {Promise<string>} The generated IPFS hash (CIDv0).
+ */
+export async function generateIPFSHash(content) {
+  if (!content) return "";
+
+  const encoder = new TextEncoder();
+  const data = encoder.encode(content);
+
+  // Use Web Crypto API for secure SHA-256 hashing
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = new Uint8Array(hashBuffer);
+
+  // CIDv0 format: <multihash-type><length><hash-digest>
+  // 0x12 = SHA2-256, 0x20 = 32 bytes length
+  const multihash = new Uint8Array(2 + hashArray.length);
+  multihash[0] = 0x12;
+  multihash[1] = 0x20;
+  multihash.set(hashArray, 2);
+
+  return base58Encode(multihash);
+}

--- a/frontend/src/utils/ipfs.test.js
+++ b/frontend/src/utils/ipfs.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { generateIPFSHash } from './ipfs';
+
+// Mock crypto if not available in environment
+if (typeof crypto === 'undefined') {
+  global.crypto = {
+    subtle: {
+      digest: async (algo, data) => {
+        // Simple mock of SHA-256 for testing purposes if Web Crypto is missing
+        // In a real browser/Node 19+ this won't be needed
+        return new Uint8Array(32).fill(1).buffer;
+      }
+    }
+  };
+}
+
+describe('generateIPFSHash', () => {
+  it('should generate a Qm-prefixed hash', async () => {
+    const hash = await generateIPFSHash('test content');
+    expect(hash).toMatch(/^Qm/);
+  });
+
+  it('should be deterministic', async () => {
+    const content = 'hello world';
+    const hash1 = await generateIPFSHash(content);
+    const hash2 = await generateIPFSHash(content);
+    expect(hash1).toBe(hash2);
+  });
+
+  it('should return empty string for empty input', async () => {
+    const hash = await generateIPFSHash('');
+    expect(hash).toBe('');
+  });
+});


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
The application was using `Math.random().toString(36)` to simulate IPFS hashes when publishing notices. `Math.random()` is cryptographically insecure and predictable.

### ⚠️ Risk: The potential impact if left unfixed
Insecure randomness can lead to predictable hash generation, which might result in collisions or allow an attacker to pre-calculate hashes for specific content, potentially leading to tampering or spoofing in systems that rely on these identifiers for integrity.

### 🛡️ Solution: How the fix addresses the vulnerability
The fix introduces a secure `generateIPFSHash` utility in `frontend/src/utils/ipfs.js`. This utility:
1.  Uses `crypto.subtle.digest('SHA-256', ...)` (Web Crypto API) to generate a secure hash of the actual notice content.
2.  Prepends the standard IPFS multihash prefix (`0x1220` for SHA-256).
3.  Encodes the result using a custom Base58 implementation to produce authentic-looking `Qm...` CIDv0 hashes.
4.  Ensures hashing is deterministic (same content always produces the same hash), mirroring real IPFS behavior.

The `handlePublish` function in `App.jsx` was updated to use this utility, making the hashing process both secure and functionally accurate.

---
*PR created automatically by Jules for task [15111252436867725996](https://jules.google.com/task/15111252436867725996) started by @revxi*