### PR TITLE
🧹 Remove unused useDisconnect import from App.jsx

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useEffect, useCallback } from "react";
-import { useAccount, useConnect, useDisconnect, useReadContract, useReadContracts, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
+import { useAccount, useConnect, useReadContract, useReadContracts, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
 import ABI from "./utils/abi.json";
 import { Search, ShieldCheck, User, Wallet, LayoutGrid } from "lucide-react";
 import AdminPanel from "./components/AdminPanel";


### PR DESCRIPTION
This PR removes the unused `useDisconnect` import from `frontend/src/App.jsx`.

🎯 **What:** The `useDisconnect` hook was imported from `wagmi` but never utilized within the component.
💡 **Why:** Removing dead code reduces clutter, improves readability, and follows best practices for maintainable code.
✅ **Verification:**
- Verified that `useDisconnect` is indeed not used in the file via `grep`.
- Confirmed the file content after removal.
- Attempted to run lint and tests (acknowledging environment-specific dependency limitations).
- Received a positive code review rating.
✨ **Result:** A cleaner and more maintainable `App.jsx` file.

---
*PR created automatically by Jules for task [17997056777269556362](https://jules.google.com/task/17997056777269556362) started by @revxi*