### PR TITLE
🔒 Fix syntax error in BlockNotice.sol

### DIFF
--- a/blockchain/contracts/BlockNotice.sol
+++ b/blockchain/contracts/BlockNotice.sol
@@ -12,7 +12,6 @@ contract BlockNotice {
         require(msg.sender == admin, "Only admin can perform this action");
         _;
     }
-    address public owner;
 
     struct Notice {
         uint256 id;
@@ -35,16 +34,6 @@ contract BlockNotice {
     );
 
     function postNotice(string memory _title, string memory _content) public onlyAdmin {
-    constructor() {
-        owner = msg.sender;
-    }
-
-    modifier onlyOwner() {
-        require(msg.sender == owner, "Not owner");
-        _;
-    }
-
-    function postNotice(string memory _title, string memory _content) public onlyOwner {
         uint256 noticeId = notices.length;
         notices.push(
             Notice(noticeId, msg.sender, _title, _content, block.timestamp)

--- a/blockchain/test/BlockNotice.test.cjs
+++ b/blockchain/test/BlockNotice.test.cjs
@@ -2,28 +2,31 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("BlockNotice", function () {
-  let BlockNotice;
   let blockNotice;
-  let owner;
+  let admin;
   let addr1;
   let addr2;
 
   beforeEach(async function () {
-    [owner, addr1, addr2] = await ethers.getSigners();
+    [admin, addr1, addr2] = await ethers.getSigners();
     const BlockNotice = await ethers.getContractFactory("BlockNotice");
-    BlockNotice = await ethers.getContractFactory("BlockNotice");
-    [owner, addr1, addr2] = await ethers.getSigners();
     blockNotice = await BlockNotice.deploy();
     await blockNotice.waitForDeployment();
   });
 
+  describe("Deployment", function () {
+    it("Should set the right admin", async function () {
+      expect(await blockNotice.admin()).to.equal(admin.address);
+    });
+  });
+
   describe("postNotice", function () {
-    it("Should post a new notice successfully", async function () {
+    it("Should allow admin to post a new notice successfully", async function () {
       const title = "Test Notice";
       const content = "This is a test notice content.";
 
       // Capture the transaction
-      const tx = await blockNotice.connect(addr1).postNotice(title, content);
+      const tx = await blockNotice.connect(admin).postNotice(title, content);
 
       // Wait for the transaction to be mined
       const receipt = await tx.wait();
@@ -34,67 +37,64 @@ describe("BlockNotice", function () {
       // Check for the event
       await expect(tx)
         .to.emit(blockNotice, "NoticePosted")
-        .withArgs(0, addr1.address, title, block.timestamp);
+        .withArgs(0n, admin.address, title, block.timestamp);
 
       // Check if the notice is stored correctly
       const notice = await blockNotice.notices(0);
       expect(notice.id).to.equal(0n);
-      expect(notice.author).to.equal(addr1.address);
+      expect(notice.author).to.equal(admin.address);
       expect(notice.title).to.equal(title);
       expect(notice.content).to.equal(content);
-      expect(notice.timestamp).to.equal(block.timestamp);
+      expect(notice.timestamp).to.equal(BigInt(block.timestamp));
 
       // Check if the notice ID is added to userNotices
-      const userNotices = await blockNotice.getUserNotices(addr1.address);
+      const userNotices = await blockNotice.getUserNotices(admin.address);
       expect(userNotices.length).to.equal(1);
       expect(userNotices[0]).to.equal(0n);
     });
 
-    it("Should handle multiple notices from different users", async function () {
-        await blockNotice.connect(addr1).postNotice("Title 1", "Content 1");
-        await blockNotice.connect(addr2).postNotice("Title 2", "Content 2");
-        await blockNotice.connect(addr1).postNotice("Title 3", "Content 3");
+    it("Should prevent non-admins from posting a notice", async function () {
+      const title = "Unauthorized Notice";
+      const content = "Unauthorized Content";
+
+      await expect(
+        blockNotice.connect(addr1).postNotice(title, content)
+      ).to.be.revertedWith("Only admin can perform this action");
+    });
+
+    it("Should handle multiple notices from admin", async function () {
+        await blockNotice.connect(admin).postNotice("Title 1", "Content 1");
+        await blockNotice.connect(admin).postNotice("Title 2", "Content 2");
 
         const count = await blockNotice.getNoticeCount();
-        expect(count).to.equal(3n);
+        expect(count).to.equal(2n);
 
-        const userNotices1 = await blockNotice.getUserNotices(addr1.address);
-        expect(userNotices1.length).to.equal(2);
-        expect(userNotices1[0]).to.equal(0n);
-        expect(userNotices1[1]).to.equal(2n);
-
-        const userNotices2 = await blockNotice.getUserNotices(addr2.address);
-        expect(userNotices2.length).to.equal(1);
-        expect(userNotices2[0]).to.equal(1n);
+        const userNotices = await blockNotice.getUserNotices(admin.address);
+        expect(userNotices.length).to.equal(2);
+        expect(userNotices[0]).to.equal(0n);
+        expect(userNotices[1]).to.equal(1n);
     });
 
     it("Should handle empty title and content", async function () {
-        await blockNotice.connect(addr1).postNotice("", "");
+        await blockNotice.connect(admin).postNotice("", "");
         const notice = await blockNotice.notices(0);
         expect(notice.title).to.equal("");
         expect(notice.content).to.equal("");
     });
-  it("Should set the right owner", async function () {
-    expect(await blockNotice.owner()).to.equal(owner.address);
   });
 
-  it("Should prevent non-owners from posting a notice", async function () {
-    const title = "Test Notice";
-    const content = "Test Content";
+  describe("getNotice", function () {
+    it("Should revert if notice does not exist", async function () {
+      await expect(blockNotice.getNotice(0))
+        .to.be.revertedWithCustomError(blockNotice, "NoticeDoesNotExist")
+        .withArgs(0);
+    });
 
-    await expect(
-      blockNotice.connect(addr1).postNotice(title, content)
-    ).to.be.revertedWith("Not owner");
-  });
-
-  it("Should allow owner to post a notice", async function () {
-    const title = "Official Notice";
-    const content = "Official Content";
-
-    await expect(blockNotice.postNotice(title, content))
-      .to.emit(blockNotice, "NoticePosted");
-
-    const count = await blockNotice.getNoticeCount();
-    expect(count).to.equal(1);
+    it("Should return the correct notice", async function () {
+      await blockNotice.connect(admin).postNotice("Title", "Content");
+      const notice = await blockNotice.getNotice(0);
+      expect(notice.title).to.equal("Title");
+      expect(notice.content).to.equal("Content");
+    });
   });
 });


### PR DESCRIPTION
### 🎯 What:
Fixed a critical syntax error in `BlockNotice.sol` where a constructor and modifier were incorrectly nested inside the `postNotice` function definition. Standardized the contract's access control by removing the redundant `owner` role in favor of the existing `admin` role.

### ⚠️ Risk:
The syntax error prevented the contract from compiling and being deployed. The redundant and conflicting access control logic (`owner` vs `admin`) could have led to authorization bypasses or inconsistent state if left unfixed.

### 🛡️ Solution:
- Cleaned up the `BlockNotice.sol` contract by removing the nested code blocks and consolidating the function declarations.
- Removed the unused `owner` variable and `onlyOwner` modifier, ensuring all administrative actions consistently use the `onlyAdmin` modifier.
- Refactored the test suite in `BlockNotice.test.cjs` to use the `admin` account and verify the correct revert messages, ensuring the security fix is properly validated.

---
*PR created automatically by Jules for task [2333962359295885181](https://jules.google.com/task/2333962359295885181) started by @revxi*