### PR TITLE
⚡ Optimize Notice Fetching with Single Batch Query

### DIFF
--- a/blockchain/contracts/BlockNotice.sol
+++ b/blockchain/contracts/BlockNotice.sol
@@ -4,16 +4,6 @@ pragma solidity ^0.8.19;
 contract BlockNotice {
     address public admin;
 
-    constructor() {
-        admin = msg.sender;
-    }
-
-    modifier onlyAdmin() {
-        require(msg.sender == admin, "Only admin can perform this action");
-        _;
-    }
-    address public owner;
-
     struct Notice {
         uint256 id;
         address author;
@@ -34,17 +24,16 @@ contract BlockNotice {
         uint256 timestamp
     );
 
-    function postNotice(string memory _title, string memory _content) public onlyAdmin {
     constructor() {
-        owner = msg.sender;
+        admin = msg.sender;
     }
 
-    modifier onlyOwner() {
-        require(msg.sender == owner, "Not owner");
+    modifier onlyAdmin() {
+        require(msg.sender == admin, "Only admin can perform this action");
         _;
     }
 
-    function postNotice(string memory _title, string memory _content) public onlyOwner {
+    function postNotice(string memory _title, string memory _content) public onlyAdmin {
         uint256 noticeId = notices.length;
         notices.push(
             Notice(noticeId, msg.sender, _title, _content, block.timestamp)
@@ -73,5 +62,9 @@ contract BlockNotice {
         returns (uint256[] memory)
     {
         return userNotices[_user];
+    }
+
+    function getAllNotices() public view returns (Notice[] memory) {
+        return notices;
     }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,35 +34,12 @@ export default function App() {
 
   const isPublishing = isWritePending || isConfirming;
 
-  // Read Notice Count
-  const { data: noticeCount, refetch: refetchCount } = useReadContract({
+  // Read all notices in a single call
+  const { data: noticesData, refetch: fetchNotices } = useReadContract({
     address: CONTRACT_ADDRESS,
     abi: ABI,
-    functionName: 'getNoticeCount',
+    functionName: 'getAllNotices',
   });
-
-  // Prepare calls for all notices
-  const noticeContracts = useMemo(() => {
-    if (!noticeCount) return [];
-    const count = Number(noticeCount);
-    return Array.from({ length: count }, (_, i) => ({
-      address: CONTRACT_ADDRESS,
-      abi: ABI,
-      functionName: 'getNotice',
-      args: [BigInt(i)],
-    }));
-  }, [noticeCount]);
-
-  // Read all notices in parallel
-  const { data: noticesData, refetch: refetchNotices } = useReadContracts({
-    contracts: noticeContracts,
-  });
-
-  // Memoized fetch function for notices
-  const fetchNotices = useCallback(() => {
-    refetchCount();
-    refetchNotices();
-  }, [refetchCount, refetchNotices]);
 
   // Refetch notices when transaction is confirmed
   useEffect(() => {
@@ -74,9 +51,7 @@ export default function App() {
   // Process notices data
   const notices = useMemo(() => {
     if (!noticesData) return [];
-    return noticesData
-      .map((result) => result.result)
-      .filter((n) => n)
+    return [...noticesData]
       .map((n) => ({
         id: n.id.toString(),
         title: n.title,

--- a/frontend/src/utils/abi.json
+++ b/frontend/src/utils/abi.json
@@ -109,6 +109,46 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "getAllNotices",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "id",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "author",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "title",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "content",
+            "type": "string"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BlockNotice.Notice[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {


### PR DESCRIPTION
💡 **What:**
- Implemented `getAllNotices` function in `BlockNotice.sol` to return the entire notices array.
- Cleaned up corrupted contract code (removed duplicate constructors and modifiers).
- Updated the frontend ABI to include `getAllNotices`.
- Refactored `App.jsx` to use a single `useReadContract` call for `getAllNotices`, replacing the N+1 pattern where `noticeCount` was fetched first followed by individual `getNotice` calls for every index.

🎯 **Why:**
- The previous implementation suffered from an N+1 query pattern, which is highly inefficient on the blockchain. Fetching `N` notices required `N+1` separate RPC calls (or a multicall with `N` entries).
- Using a single `getAllNotices` call reduces network overhead and improves frontend load times significantly, especially as the number of notices grows.

📊 **Measured Improvement:**
- While environmental restrictions prevented live benchmarking, the theoretical improvement is a reduction from O(N) network requests to O(1) for data fetching. This eliminates the latency bottleneck caused by serial or even parallel individual contract reads.

---
*PR created automatically by Jules for task [13369107127436360835](https://jules.google.com/task/13369107127436360835) started by @revxi*