### PR TITLE
🧹 Remove unused useDisconnect import in App.jsx

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useEffect, useCallback } from "react";
-import { useAccount, useConnect, useDisconnect, useReadContract, useReadContracts, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
+import { useAccount, useConnect, useReadContract, useReadContracts, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
 import ABI from "./utils/abi.json";
 import { Search, ShieldCheck, User, Wallet, LayoutGrid } from "lucide-react";
 import AdminPanel from "./components/AdminPanel";


### PR DESCRIPTION
This PR addresses a minor code health issue by removing an unused import.

🎯 **What:** The unused `useDisconnect` import from `wagmi` was removed from `frontend/src/App.jsx`.
💡 **Why:** Removing unused code reduces clutter, improves readability, and avoids confusion for future developers.
✅ **Verification:** Manually verified that `useDisconnect` was not being used anywhere in `frontend/src/App.jsx` and that the remaining imports are correctly formatted. Checked for syntax errors after removal.
✨ **Result:** A cleaner `App.jsx` with only necessary imports.

---
*PR created automatically by Jules for task [9165184558892127744](https://jules.google.com/task/9165184558892127744) started by @revxi*