### PR TITLE
🧹 Replace deprecated addListener with standard addEventListener in ThemeContext

### DIFF
--- a/frontend/src/context/ThemeContext.jsx
+++ b/frontend/src/context/ThemeContext.jsx
@@ -36,16 +36,8 @@ export const ThemeProvider = ({ children }) => {
       }
     };
 
-    // Modern browsers
-    if (mediaQuery.addEventListener) {
-      mediaQuery.addEventListener("change", handleChange);
-      return () => mediaQuery.removeEventListener("change", handleChange);
-    }
-    // Older browsers
-    else {
-      mediaQuery.addListener(handleChange);
-      return () => mediaQuery.removeListener(handleChange);
-    }
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
   }, [theme]);
 
   const applyTheme = (selectedTheme, systemIsDark = false) => {


### PR DESCRIPTION
🎯 **What:** The deprecated `mediaQuery.addListener` and `mediaQuery.removeListener` API methods have been replaced with standard `addEventListener` and `removeEventListener`.

💡 **Why:** `addListener` and `removeListener` on MediaQueryList objects are considered deprecated and can pose maintainability risks or trigger warnings in modern development environments. Standardizing on `addEventListener` improves code health and aligns with standard DOM event patterns.

✅ **Verification:** Verified that the frontend application builds cleanly using Vite and the modified `ThemeContext.jsx` file contains no syntax errors. Since it deals with a fundamental DOM event change that is robust across modern browsers, tests confirmed the component integrates properly. Pre-commit test runs confirmed there were no new regressions.

✨ **Result:** Improved maintainability, modernized event subscription logic for system theme change detection, and reduced reliance on deprecated browser APIs.

---
*PR created automatically by Jules for task [9003800136182016439](https://jules.google.com/task/9003800136182016439) started by @revxi*