### PR TITLE
🔒 Fix hardcoded smart contract address in frontend

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 
-const contractAddress = "0x5FbDB2315678afccb333f8a9c6122f65385ba4c8a";
+const contractAddress = typeof process !== 'undefined' ? process.env.VITE_CONTRACT_ADDRESS : import.meta.env.VITE_CONTRACT_ADDRESS;
 
 const abi = [
   "function getAllNotices() view returns (tuple(uint id,string title,string content,uint timestamp)[])",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,7 +9,7 @@ import NoticeFeed from "./components/NoticeFeed";
 import Login from "./components/Login";
 import ThemeSelector from "./components/ThemeSelector";
 
-const CONTRACT_ADDRESS = "0x5FbDB2315678afccb333f8a9c6122f65385ba4c8a";
+const CONTRACT_ADDRESS = import.meta.env.VITE_CONTRACT_ADDRESS;
 
 export default function App() {
   const { address: account } = useAccount();

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -4,7 +4,7 @@ import { findInjectedConnector, isMetaMaskInstalled } from "../utils/connectors"
 import { AlertCircle, Shield, ArrowRight, Wallet } from "lucide-react";
 import ABI from "../utils/abi.json";
 
-const CONTRACT_ADDRESS = "0x5FbDB2315678afccb333f8a9c6122f65385ba4c8a";
+const CONTRACT_ADDRESS = import.meta.env.VITE_CONTRACT_ADDRESS;
 
 export default function Login({ onLogin }) {
   const { address: account } = useAccount();


### PR DESCRIPTION
🔒 Fixed a security vulnerability where the smart contract address was hardcoded into the application source code across multiple files (`App.jsx`, `Login.jsx`, `contract.js`).

**Risk:** Hardcoded addresses prevent flexible deployments across different environments (e.g., testnet vs. mainnet) and expose specific network configurations directly in the codebase, which violates security best practices for environment-specific secrets and configurations.

**Solution:** Removed the hardcoded address strings and replaced them with standard environment variable lookups. In the Vite frontend context, `import.meta.env.VITE_CONTRACT_ADDRESS` is used directly (without optional chaining, to ensure Vite's static replacement works). In the shared `contract.js` utility, conditional logic safely falls back to `process.env.VITE_CONTRACT_ADDRESS` when executing in a Node.js environment.

---
*PR created automatically by Jules for task [3541505709619826719](https://jules.google.com/task/3541505709619826719) started by @revxi*